### PR TITLE
fix(vanguard): update plugin to use holdings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Chrome/Firefox browser extension that syncs account balances from financial in
 
 ## Supported sources
 
-- **Vanguard** — scrapes balances from the portfolio overview page
+- **Vanguard** — scrapes balances from the holdings tab
 - **Alight** — scrapes balances from the retirement overview page
 - **Monarch** — scrapes balances from the Accounts page
 - **YNAB** — fetches balances via the YNAB API using a Personal Access Token

--- a/e2e/mock-sites.spec.ts
+++ b/e2e/mock-sites.spec.ts
@@ -30,8 +30,10 @@ test("refreshes Vanguard accounts from mock tab", async ({
 
 	await expect(popup.getByText("Roth IRA")).toBeVisible({ timeout: 10_000 });
 	await expect(popup.getByText("Traditional 401k")).toBeVisible();
+	await expect(popup.getByText("529 College Savings")).toBeVisible();
 	await expect(popup.getByText("$1,200")).toBeVisible();
 	await expect(popup.getByText("$1,850")).toBeVisible();
+	await expect(popup.getByText("$1,500")).toBeVisible();
 });
 
 test("loads ProjectionLab accounts into dropdowns from mock tab", async ({
@@ -74,6 +76,7 @@ test("full sync: Vanguard → ProjectionLab", async ({
 	await popup.getByRole("button", { name: /↻ Vanguard/ }).click();
 	await expect(popup.getByText("Roth IRA")).toBeVisible({ timeout: 10_000 });
 	await expect(popup.getByText("Traditional 401k")).toBeVisible();
+	await expect(popup.getByText("529 College Savings")).toBeVisible();
 
 	// Step 2: open PL tab then pull PL accounts from Settings
 	await openMockTab(context, PL_URL);
@@ -84,16 +87,19 @@ test("full sync: Vanguard → ProjectionLab", async ({
 	const selects = popup.locator("select");
 	await expect(selects.first()).toBeEnabled({ timeout: 10_000 });
 
-	// Step 3: map both accounts
+	// Step 3: map all three accounts (including the outside investment)
 	await selects.nth(0).selectOption("pl-roth-ira");
 	await selects.nth(1).selectOption("pl-401k");
+	await selects.nth(2).selectOption("pl-529");
 
 	// Step 4: sync
 	await popup.getByRole("button", { name: "Sync to ProjectionLab" }).click();
 
-	// Step 5: verify results
+	// Step 5: verify results — outside investment proves the sync covers
+	// accounts whose ids come from `scroll-to-id` (no `data-testid`).
 	await expect(popup.getByText(/✓.*Roth IRA/)).toBeVisible({ timeout: 10_000 });
 	await expect(popup.getByText(/✓.*Traditional 401k/)).toBeVisible();
+	await expect(popup.getByText(/✓.*529 College Savings/)).toBeVisible();
 });
 
 test("refreshes Alight accounts from mock tab", async ({

--- a/e2e/mock-sites/projectionlab/index.html
+++ b/e2e/mock-sites/projectionlab/index.html
@@ -7,6 +7,7 @@
     const MOCK_ACCOUNTS = [
       { id: "pl-roth-ira", name: "Roth IRA" },
       { id: "pl-401k", name: "Traditional 401k" },
+      { id: "pl-529", name: "529 College Savings" },
     ];
 
     const updates = {};

--- a/e2e/popup.spec.ts
+++ b/e2e/popup.spec.ts
@@ -41,7 +41,7 @@ test("switches active plugin when sidebar button clicked", async ({ page }) => {
 });
 
 test("shows empty state with refresh prompt for Vanguard", async ({ page }) => {
-	await expect(page.getByText(/Open Vanguard/)).toBeVisible();
+	await expect(page.getByText(/Navigate to the holdings tab/)).toBeVisible();
 });
 
 test("shows source refresh button in panel header", async ({ page }) => {

--- a/plugins/vanguard/content.test.ts
+++ b/plugins/vanguard/content.test.ts
@@ -1,70 +1,138 @@
 import { describe, expect, it } from "vitest";
-import { extractAccountId, extractPortfolio } from "./content";
+import { cleanName, extractAccountId, extractPortfolio } from "./content";
 
 describe("extractAccountId", () => {
-	it("extracts accountId from href", () => {
-		expect(extractAccountId("https://example.com?ss-accountIds=12345")).toBe(
-			"12345",
-		);
+	it("returns the scroll-to-id value", () => {
+		expect(extractAccountId("123456789012345")).toBe("123456789012345");
 	});
 
-	it("returns null when param is missing", () => {
-		expect(extractAccountId("https://example.com/other")).toBeNull();
+	it("trims whitespace", () => {
+		expect(extractAccountId("  987654321098765  ")).toBe("987654321098765");
 	});
 
-	it("returns null for undefined", () => {
-		expect(extractAccountId(undefined)).toBeNull();
+	it("returns null for null", () => {
+		expect(extractAccountId(null)).toBeNull();
 	});
 
 	it("returns null for empty string", () => {
 		expect(extractAccountId("")).toBeNull();
 	});
+
+	it("returns null for whitespace-only", () => {
+		expect(extractAccountId("   ")).toBeNull();
+	});
+});
+
+describe("cleanName", () => {
+	it("strips trailing ' - <digits>*' suffix", () => {
+		expect(cleanName("Brokerage Account - 11111111*")).toBe(
+			"Brokerage Account",
+		);
+	});
+
+	it("strips with extra whitespace around the suffix", () => {
+		expect(cleanName("Roth IRA  -  22222* ")).toBe("Roth IRA");
+	});
+
+	it("returns the name unchanged when there is no masked-id suffix", () => {
+		expect(cleanName("Traditional 401k")).toBe("Traditional 401k");
+	});
+
+	it("does not strip a hyphen that is not followed by digits-and-asterisk", () => {
+		expect(cleanName("Joint - Brokerage")).toBe("Joint - Brokerage");
+	});
 });
 
 describe("extractPortfolio", () => {
-	it("extracts account with anchor link and accountId", () => {
+	it("strips the masked-id suffix from a self-managed account name", () => {
 		document.body.innerHTML = `
-      <div class="individual-account-container">
-        <a class="account-holdings-link" href="?ss-accountIds=99">My 401k</a>
-        <div class="balance"><span>$50,000</span></div>
-        <div class="rate-of-return"><span>8.2%</span></div>
-      </div>
+      <c11n-accordion scroll-to-id="111111111111111" data-testid="account-id:111111111111111">
+        <button class="c11n-accordion__trigger">
+          <span class="c11n-accordion__heading">Brokerage Account - 11111111*</span>
+          <span class="c11n-accordion__content">$1,234.56</span>
+        </button>
+      </c11n-accordion>
     `;
 		expect(extractPortfolio()).toEqual([
 			{
-				name: "My 401k",
-				balance: 50000,
-				accountId: "99",
+				name: "Brokerage Account",
+				balance: 1234.56,
+				accountId: "111111111111111",
 			},
 		]);
 	});
 
-	it("extracts account when name element is not an anchor", () => {
+	it("extracts an outside investment (no data-testid, no masked-id suffix)", () => {
 		document.body.innerHTML = `
-      <div class="individual-account-container">
-        <span class="account-holdings-link">Brokerage</span>
-        <div class="balance"><span>$10,000</span></div>
-      </div>
+      <c11n-accordion scroll-to-id="222222222222222">
+        <button class="c11n-accordion__trigger">
+          <span class="c11n-accordion__heading">529 College Savings</span>
+          <span class="c11n-accordion__content">$1,500.00</span>
+        </button>
+      </c11n-accordion>
     `;
-		const result = extractPortfolio();
-		expect(result[0].name).toBe("Brokerage");
-		expect(result[0].accountId).toBeNull();
+		expect(extractPortfolio()).toEqual([
+			{
+				name: "529 College Savings",
+				balance: 1500,
+				accountId: "222222222222222",
+			},
+		]);
+	});
+
+	it("extracts both self-managed and outside investments in document order", () => {
+		document.body.innerHTML = `
+      <app-holdings-table data-testid="self-managed-accounts_table">
+        <c11n-accordion scroll-to-id="111" data-testid="account-id:111">
+          <span class="c11n-accordion__heading">Brokerage Account - 11111111*</span>
+          <span class="c11n-accordion__content">$1,234.56</span>
+        </c11n-accordion>
+        <c11n-accordion scroll-to-id="222" data-testid="account-id:222">
+          <span class="c11n-accordion__heading">Roth IRA</span>
+          <span class="c11n-accordion__content">$1,800.00</span>
+        </c11n-accordion>
+      </app-holdings-table>
+      <app-private-equity scroll-to-id="private-equity"></app-private-equity>
+      <span scroll-to-id="outside-investments"></span>
+      <app-outside-investments data-testid="manual-outside-investments_table">
+        <c11n-accordion scroll-to-id="333">
+          <span class="c11n-accordion__heading">529 College Savings</span>
+          <span class="c11n-accordion__content">$1,500.00</span>
+        </c11n-accordion>
+      </app-outside-investments>
+    `;
+		expect(extractPortfolio()).toEqual([
+			{ name: "Brokerage Account", balance: 1234.56, accountId: "111" },
+			{ name: "Roth IRA", balance: 1800, accountId: "222" },
+			{ name: "529 College Savings", balance: 1500, accountId: "333" },
+		]);
+	});
+
+	it("ignores section-header elements that share scroll-to-id but are not c11n-accordion", () => {
+		document.body.innerHTML = `
+      <app-private-equity scroll-to-id="private-equity">
+        <span class="c11n-accordion__heading">Should be ignored</span>
+        <span class="c11n-accordion__content">$1.00</span>
+      </app-private-equity>
+      <span scroll-to-id="outside-investments"></span>
+    `;
+		expect(extractPortfolio()).toEqual([]);
 	});
 
 	it("skips containers missing a name", () => {
 		document.body.innerHTML = `
-      <div class="individual-account-container">
-        <div class="balance"><span>$1,000</span></div>
-      </div>
+      <c11n-accordion scroll-to-id="1">
+        <span class="c11n-accordion__content">$1,000</span>
+      </c11n-accordion>
     `;
 		expect(extractPortfolio()).toEqual([]);
 	});
 
 	it("skips containers missing a balance", () => {
 		document.body.innerHTML = `
-      <div class="individual-account-container">
-        <a class="account-holdings-link">Account</a>
-      </div>
+      <c11n-accordion scroll-to-id="1">
+        <span class="c11n-accordion__heading">Account</span>
+      </c11n-accordion>
     `;
 		expect(extractPortfolio()).toEqual([]);
 	});

--- a/plugins/vanguard/content.ts
+++ b/plugins/vanguard/content.ts
@@ -1,21 +1,25 @@
 import { createMain, parseMoney, queryDeep } from "../content-utils";
 import vanguard from "./index";
 
-export function extractAccountId(href?: string) {
-	if (!href) return null;
-	const match = href.match(/ss-accountIds=(\d+)/);
-	return match ? match[1] : null;
+export function extractAccountId(scrollToId?: string | null) {
+	return scrollToId?.trim() || null;
+}
+
+// Remove trailing * from account names
+export function cleanName(raw: string): string {
+	return raw.replace(/\s*-\s*\d+\*\s*$/, "").trim();
 }
 
 export function extractPortfolio() {
-	return queryDeep(".individual-account-container").flatMap((container) => {
-		const nameEl = container.querySelector(".account-holdings-link");
-		let href: string | null = null;
-		if (nameEl instanceof HTMLAnchorElement) href = nameEl.href;
-
-		const name = nameEl?.textContent?.trim();
+	return queryDeep("c11n-accordion[scroll-to-id]").flatMap((container) => {
+		const rawName = container
+			.querySelector(".c11n-accordion__heading")
+			?.textContent?.trim();
+		const name = rawName ? cleanName(rawName) : undefined;
 		const balance = parseMoney(
-			container.querySelector(".balance span")?.textContent?.trim() ?? null,
+			container
+				.querySelector(".c11n-accordion__content")
+				?.textContent?.trim() ?? null,
 		);
 
 		if (!name || balance === null) return [];
@@ -24,7 +28,7 @@ export function extractPortfolio() {
 			{
 				name,
 				balance,
-				accountId: extractAccountId(href ?? undefined),
+				accountId: extractAccountId(container.getAttribute("scroll-to-id")),
 			},
 		];
 	});

--- a/plugins/vanguard/index.ts
+++ b/plugins/vanguard/index.ts
@@ -6,8 +6,9 @@ const plugin: SourcePlugin = {
 	name: "Vanguard",
 	icon,
 	kind: "content",
+	hint: "Navigate to the holdings tab, then click ↻ Vanguard.",
 	urlPatterns: [
-		"https://www.vanguard.com/en/investor/portfolio/dashboard/*",
+		"https://www.vanguard.com/en/investor/portfolio/investments/*",
 		/* v8 ignore start -- E2E-only URL, covered by the mock-site E2E suite. */
 		...(__E2E__ ? ["http://localhost:3000/vanguard/*"] : []),
 		/* v8 ignore stop */

--- a/plugins/vanguard/mock-site/index.html
+++ b/plugins/vanguard/mock-site/index.html
@@ -5,15 +5,23 @@
   <title>Mock Vanguard</title>
 </head>
 <body>
-  <div class="individual-account-container">
-    <a class="account-holdings-link" href="?ss-accountIds=111">Roth IRA</a>
-    <div class="balance"><span>$1,200.00</span></div>
-    <div class="rate-of-return"><span>7.5%</span></div>
-  </div>
-  <div class="individual-account-container">
-    <a class="account-holdings-link" href="?ss-accountIds=222">Traditional 401k</a>
-    <div class="balance"><span>$1,850.00</span></div>
-    <div class="rate-of-return"><span>10.2%</span></div>
-  </div>
+  <c11n-accordion scroll-to-id="111">
+    <button class="c11n-accordion__trigger">
+      <span class="c11n-accordion__heading">Roth IRA</span>
+      <span class="c11n-accordion__content">$1,200.00</span>
+    </button>
+  </c11n-accordion>
+  <c11n-accordion scroll-to-id="222">
+    <button class="c11n-accordion__trigger">
+      <span class="c11n-accordion__heading">Traditional 401k</span>
+      <span class="c11n-accordion__content">$1,850.00</span>
+    </button>
+  </c11n-accordion>
+  <c11n-accordion scroll-to-id="333">
+    <button class="c11n-accordion__trigger">
+      <span class="c11n-accordion__heading">529 College Savings</span>
+      <span class="c11n-accordion__content">$1,500.00</span>
+    </button>
+  </c11n-accordion>
 </body>
 </html>


### PR DESCRIPTION
- Changes Vanguard to use the "Holdings" page for accounts
- Includes outside investments in accounts to sync to ProjectionLab
- Updates associated tests to match the new page

Closes: #41 