### PR TITLE
feat(sync): Enable splitting source accounts

### DIFF
--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -34,7 +34,7 @@ async function launchDemoContext(dsr = 2): Promise<BrowserContext> {
 	const context = await chromium.launchPersistentContext("", {
 		headless: false,
 		deviceScaleFactor: dsr,
-		viewport: { width: 460, height: 480 },
+		viewport: { width: 540, height: 480 },
 		args: [
 			`--disable-extensions-except=${extPath}`,
 			`--load-extension=${extPath}`,
@@ -98,7 +98,7 @@ function buildMarqueePromo(icon: string, popupBase64: string): string {
   .title { color: white; font-size: 52px; font-weight: 700; letter-spacing: -0.02em; line-height: 1.1; }
   .tagline { color: rgba(255,255,255,0.88); font-size: 20px; font-weight: 500; line-height: 1.45; }
   .popup {
-    width: 460px; height: 480px;
+    width: 540px; height: 480px;
     border-radius: 12px;
     overflow: hidden;
     box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.2), 0 25px 70px rgba(99, 102, 241, 0.25);
@@ -144,7 +144,7 @@ function buildStoreFrame(popupBase64: string, caption: string): string {
     line-height: 1.25;
   }
   .popup {
-    width: 460px; height: 480px;
+    width: 540px; height: 480px;
     border-radius: 12px;
     overflow: hidden;
     box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.2), 0 25px 70px rgba(99, 102, 241, 0.25);
@@ -202,7 +202,7 @@ test.describe("Screenshots", () => {
 
 	test("chrome store shots", async () => {
 		// CWS requires 1280x800 JPEG or 24-bit PNG (no alpha). Use DSR=1 for pixel-crisp
-		// popup rendering at its natural 460x480 size inside the 1280x800 frame.
+		// popup rendering at its natural 540x480 size inside the 1280x800 frame.
 		const context = await launchDemoContext(1);
 		try {
 			await mkdir("docs/store/chrome", { recursive: true });

--- a/e2e/splits.spec.ts
+++ b/e2e/splits.spec.ts
@@ -1,0 +1,383 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./fixtures";
+import {
+	clearStorage,
+	getServiceWorker,
+	openMockTab,
+	openPopup,
+	seedStorage,
+} from "./helpers";
+
+const VANGUARD_URL = "http://localhost:3000/vanguard/";
+const ALIGHT_URL = "http://localhost:3000/alight/";
+const PL_URL = "http://localhost:3000/projectionlab/";
+
+// Vanguard mock balances (kept in sync with mock-sites/vanguard):
+// Roth IRA $1200, Traditional 401k $1850, 529 College Savings $1500.
+// Alight mock: 401(k) — Core $1650, HSA — Health Savings $1050.
+
+test.beforeEach(async ({ context }) => {
+	const sw = await getServiceWorker(context);
+	await clearStorage(sw);
+	await seedStorage(sw, { plApiKey: "test-key" });
+});
+
+/**
+ * Bring the popup to a state where:
+ * - Vanguard accounts are scraped & visible
+ * - PL accounts are loaded into dropdowns
+ * - The active panel is Vanguard
+ *
+ * Returns the popup `Page` and the PL mock `Page` (so callers can read
+ * `__mockPlUpdates` after a sync).
+ */
+async function setupVanguardWithPL(
+	context: Parameters<typeof openPopup>[0],
+	popupBaseUrl: string,
+): Promise<{ popup: Page; plPage: Page }> {
+	await openMockTab(context, VANGUARD_URL);
+	const popup = await openPopup(context, popupBaseUrl);
+
+	await popup.getByRole("button", { name: /↻ Vanguard/ }).click();
+	await expect(popup.getByText("Roth IRA").first()).toBeVisible({
+		timeout: 10_000,
+	});
+
+	const plPage = await openMockTab(context, PL_URL);
+	await popup.getByTitle("Settings").click();
+	await popup.getByRole("button", { name: "↻ Refresh" }).click();
+	await expect(popup.getByText(/\d+ loaded/)).toBeVisible({ timeout: 10_000 });
+	await popup.getByTitle("Vanguard").click();
+	await expect(popup.locator("select").first()).toBeEnabled({
+		timeout: 10_000,
+	});
+
+	return { popup, plPage };
+}
+
+/** Scope to the SplitEditor card for the Nth account row (1-based). */
+function legSelect(popup: Page, legIndex: number) {
+	return popup.getByRole("combobox", {
+		name: new RegExp(`Split leg ${legIndex} PL account`, "i"),
+	});
+}
+
+function legValue(popup: Page, legIndex: number) {
+	return popup.getByRole("spinbutton", {
+		name: new RegExp(`Split leg ${legIndex} value`, "i"),
+	});
+}
+
+/**
+ * Click the mode pill for a given leg. The fieldset has an `sr-only` legend
+ * "Split leg N mode" so we scope by it.
+ */
+async function setLegMode(
+	popup: Page,
+	legIndex: number,
+	mode: "%" | "$" | "rest",
+) {
+	const fieldset = popup.locator(
+		`fieldset:has(legend:has-text("Split leg ${legIndex} mode"))`,
+	);
+	await fieldset.getByRole("button", { name: mode, exact: true }).click();
+}
+
+test("percent split distributes balance across two PL accounts", async ({
+	context,
+	popupBaseUrl,
+}) => {
+	const { popup, plPage } = await setupVanguardWithPL(context, popupBaseUrl);
+
+	// Single-map the Roth IRA row first so the seed split picks it up at 100%.
+	await popup.locator("select").nth(0).selectOption("pl-roth-ira");
+
+	// Convert to a split.
+	await popup
+		.getByRole("button", { name: /split into multiple/i })
+		.first()
+		.click();
+
+	// First leg seeded as 100% pl-roth-ira. Drop it to 60.
+	await expect(legSelect(popup, 1)).toHaveValue("pl-roth-ira");
+	await legValue(popup, 1).fill("60");
+
+	// Add a second leg, point at pl-401k, percent stays default at 0 — set to 40.
+	await popup.getByRole("button", { name: /\+ add target/i }).click();
+	await legSelect(popup, 2).selectOption("pl-401k");
+	await legValue(popup, 2).fill("40");
+
+	// Status should read totals match.
+	await expect(popup.getByText(/Total: \$1,200 of \$1,200/)).toBeVisible();
+
+	const syncBtn = popup.getByRole("button", { name: "Sync to ProjectionLab" });
+	await expect(syncBtn).toBeEnabled();
+	await syncBtn.click();
+	await expect(popup.getByText(/✓.*Roth IRA/).first()).toBeVisible({
+		timeout: 10_000,
+	});
+
+	// Both PL accounts received their share. 60% × $1200 = $720, 40% = $480.
+	const pushed = await plPage.evaluate(
+		() => (window as any).__mockPlUpdates ?? {},
+	);
+	expect(pushed["pl-roth-ira"]).toBe(720);
+	expect(pushed["pl-401k"]).toBe(480);
+});
+
+test("fixed leg paired with remainder pushes exact amounts", async ({
+	context,
+	popupBaseUrl,
+}) => {
+	const { popup, plPage } = await setupVanguardWithPL(context, popupBaseUrl);
+
+	await popup.locator("select").nth(0).selectOption("pl-roth-ira");
+	await popup
+		.getByRole("button", { name: /split into multiple/i })
+		.first()
+		.click();
+
+	// Leg 1: fixed $500 to pl-roth-ira.
+	await setLegMode(popup, 1, "$");
+	await legValue(popup, 1).fill("500");
+
+	// Leg 2: remainder to pl-401k.
+	await popup.getByRole("button", { name: /\+ add target/i }).click();
+	await legSelect(popup, 2).selectOption("pl-401k");
+	await setLegMode(popup, 2, "rest");
+
+	const syncBtn = popup.getByRole("button", { name: "Sync to ProjectionLab" });
+	await expect(syncBtn).toBeEnabled();
+	await syncBtn.click();
+	await expect(popup.getByText(/✓.*Roth IRA/).first()).toBeVisible({
+		timeout: 10_000,
+	});
+
+	const pushed = await plPage.evaluate(
+		() => (window as any).__mockPlUpdates ?? {},
+	);
+	expect(pushed["pl-roth-ira"]).toBe(500);
+	expect(pushed["pl-401k"]).toBe(700); // $1200 − $500
+});
+
+test("ignored leg is dropped from sync entries", async ({
+	context,
+	popupBaseUrl,
+}) => {
+	const { popup, plPage } = await setupVanguardWithPL(context, popupBaseUrl);
+
+	await popup.locator("select").nth(0).selectOption("pl-roth-ira");
+	await popup
+		.getByRole("button", { name: /split into multiple/i })
+		.first()
+		.click();
+
+	// Leg 1: 60% to pl-roth-ira.
+	await legValue(popup, 1).fill("60");
+
+	// Leg 2: 40% to "Don't sync this portion".
+	await popup.getByRole("button", { name: /\+ add target/i }).click();
+	await legSelect(popup, 2).selectOption("__ignore__");
+	await legValue(popup, 2).fill("40");
+
+	// (ignored) annotation appears next to the resolved amount.
+	await expect(popup.getByText(/\(ignored\)/i)).toBeVisible();
+
+	const syncBtn = popup.getByRole("button", { name: "Sync to ProjectionLab" });
+	await expect(syncBtn).toBeEnabled();
+	await syncBtn.click();
+	await expect(popup.getByText(/✓.*Roth IRA/).first()).toBeVisible({
+		timeout: 10_000,
+	});
+
+	const pushed = await plPage.evaluate(
+		() => (window as any).__mockPlUpdates ?? {},
+	);
+	// Only the real PL target was pushed; the ignored share went nowhere.
+	expect(pushed["pl-roth-ira"]).toBe(720);
+	expect(Object.keys(pushed)).toEqual(["pl-roth-ira"]);
+});
+
+test("under-allocated split disables the sync button until fixed", async ({
+	context,
+	popupBaseUrl,
+}) => {
+	const { popup } = await setupVanguardWithPL(context, popupBaseUrl);
+
+	await popup.locator("select").nth(0).selectOption("pl-roth-ira");
+	await popup
+		.getByRole("button", { name: /split into multiple/i })
+		.first()
+		.click();
+
+	// Leg 1: 60% (under-allocated — 40% missing, no remainder).
+	await legValue(popup, 1).fill("60");
+
+	// Validation pill calls it out and the sync button is blocked.
+	await expect(
+		popup.getByText(/Percentages total 60.0% — should be 100%/i),
+	).toBeVisible();
+	const syncBtn = popup.getByRole("button", { name: "Sync to ProjectionLab" });
+	await expect(syncBtn).toBeDisabled();
+	await expect(
+		popup.getByText(/Fix split allocation to enable sync/i),
+	).toBeVisible();
+
+	// Fix by adding a 40% leg.
+	await popup.getByRole("button", { name: /\+ add target/i }).click();
+	await legSelect(popup, 2).selectOption("pl-401k");
+	await legValue(popup, 2).fill("40");
+
+	await expect(syncBtn).toBeEnabled();
+	await expect(
+		popup.getByText(/Fix split allocation to enable sync/i),
+	).toBeHidden();
+});
+
+test("over-allocated fixed legs disable the sync button", async ({
+	context,
+	popupBaseUrl,
+}) => {
+	const { popup } = await setupVanguardWithPL(context, popupBaseUrl);
+
+	await popup.locator("select").nth(0).selectOption("pl-roth-ira");
+	await popup
+		.getByRole("button", { name: /split into multiple/i })
+		.first()
+		.click();
+
+	// Leg 1: fixed $1500 (over the $1200 balance).
+	await setLegMode(popup, 1, "$");
+	await legValue(popup, 1).fill("1500");
+
+	await expect(popup.getByText(/Over-allocated by \$300/i)).toBeVisible();
+	const syncBtn = popup.getByRole("button", { name: "Sync to ProjectionLab" });
+	await expect(syncBtn).toBeDisabled();
+});
+
+test("split mapping persists across popup reopen and round-trips through storage", async ({
+	context,
+	popupBaseUrl,
+}) => {
+	let { popup } = await setupVanguardWithPL(context, popupBaseUrl);
+
+	await popup.locator("select").nth(0).selectOption("pl-roth-ira");
+	await popup
+		.getByRole("button", { name: /split into multiple/i })
+		.first()
+		.click();
+	await legValue(popup, 1).fill("60");
+	await popup.getByRole("button", { name: /\+ add target/i }).click();
+	await legSelect(popup, 2).selectOption("pl-401k");
+	await legValue(popup, 2).fill("40");
+
+	await expect(popup.getByText(/Total: \$1,200 of \$1,200/)).toBeVisible();
+
+	// Close and reopen the popup. The seeded PL key persists; PL accounts cache
+	// in storage too. Vanguard accounts were stored on refresh.
+	await popup.close();
+	popup = await openPopup(context, popupBaseUrl);
+
+	// The split editor rehydrates with both legs at the same values.
+	await expect(legSelect(popup, 1)).toHaveValue("pl-roth-ira");
+	await expect(legValue(popup, 1)).toHaveValue("60");
+	await expect(legSelect(popup, 2)).toHaveValue("pl-401k");
+	await expect(legValue(popup, 2)).toHaveValue("40");
+
+	// Storage shape is the union { splits: [...] }, not a plain string.
+	const sw = await getServiceWorker(context);
+	const stored = (await sw.evaluate(() =>
+		(globalThis as any).chrome.storage.local.get("mappings_vanguard"),
+	)) as { mappings_vanguard: Record<string, unknown> };
+	const entry = stored.mappings_vanguard["111"]; // Roth IRA accountId per the Vanguard mock
+	expect(entry).toEqual({
+		splits: [
+			{ plId: "pl-roth-ira", mode: "percent", value: 60 },
+			{ plId: "pl-401k", mode: "percent", value: 40 },
+		],
+	});
+});
+
+test("split leg composes additively with another source's mapping to the same PL account", async ({
+	context,
+	popupBaseUrl,
+}) => {
+	// Setup: refresh both Vanguard and Alight, then load PL accounts.
+	await openMockTab(context, VANGUARD_URL);
+	await openMockTab(context, ALIGHT_URL);
+
+	const popup = await openPopup(context, popupBaseUrl);
+	await popup.getByRole("button", { name: /↻ Vanguard/ }).click();
+	await expect(popup.getByText("Roth IRA").first()).toBeVisible({
+		timeout: 10_000,
+	});
+	await popup.getByTitle("Alight").click();
+	await popup.getByRole("button", { name: /↻ Alight/ }).click();
+	await expect(popup.getByText("401(k) — Core")).toBeVisible({
+		timeout: 10_000,
+	});
+
+	const plPage = await openMockTab(context, PL_URL);
+	await popup.getByTitle("Settings").click();
+	await popup.getByRole("button", { name: "↻ Refresh" }).click();
+	await expect(popup.getByText(/\d+ loaded/)).toBeVisible({ timeout: 10_000 });
+
+	// Alight: map 401(k) — Core directly to pl-roth-ira.
+	await popup.getByTitle("Alight").click();
+	await expect(popup.locator("select").first()).toBeEnabled({
+		timeout: 10_000,
+	});
+	await popup.locator("select").nth(0).selectOption("pl-roth-ira");
+
+	// Vanguard: split Roth IRA → 60% pl-roth-ira, 40% pl-401k.
+	await popup.getByTitle("Vanguard").click();
+	await expect(popup.locator("select").first()).toBeEnabled({
+		timeout: 10_000,
+	});
+	await popup.locator("select").nth(0).selectOption("pl-roth-ira");
+	await popup
+		.getByRole("button", { name: /split into multiple/i })
+		.first()
+		.click();
+	await legValue(popup, 1).fill("60");
+	await popup.getByRole("button", { name: /\+ add target/i }).click();
+	await legSelect(popup, 2).selectOption("pl-401k");
+	await legValue(popup, 2).fill("40");
+
+	// Sync from Vanguard. The split's 60% leg ($720) plus Alight's $1650 should
+	// land in pl-roth-ira together.
+	await popup.getByRole("button", { name: "Sync to ProjectionLab" }).click();
+	await expect(popup.getByText(/✓.*Roth IRA/).first()).toBeVisible({
+		timeout: 10_000,
+	});
+
+	const pushed = await plPage.evaluate(
+		() => (window as any).__mockPlUpdates ?? {},
+	);
+	expect(pushed["pl-roth-ira"]).toBe(720 + 1650);
+	expect(pushed["pl-401k"]).toBe(480); // 40% of $1200, untouched by Alight
+});
+
+test("Cancel split returns the row to a single-mapping select", async ({
+	context,
+	popupBaseUrl,
+}) => {
+	const { popup } = await setupVanguardWithPL(context, popupBaseUrl);
+
+	await popup.locator("select").nth(0).selectOption("pl-roth-ira");
+	await popup
+		.getByRole("button", { name: /split into multiple/i })
+		.first()
+		.click();
+	await expect(legSelect(popup, 1)).toBeVisible();
+
+	await popup.getByRole("button", { name: /cancel split/i }).click();
+
+	// Editor is gone; back to the single select with "Not mapped".
+	await expect(legSelect(popup, 1)).toBeHidden();
+	const firstSelect = popup.locator("select").first();
+	await expect(firstSelect).toHaveValue("");
+	await expect(
+		firstSelect.locator("option", { hasText: "Not mapped" }),
+	).toBeAttached();
+});

--- a/entrypoints/background.test.ts
+++ b/entrypoints/background.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IGNORE_PL_ID } from "~/lib/mapping";
 import bgSetup, { getPlTab, getSourceTab } from "./background";
 
 const mockTab = { id: 1, url: "https://app.projectionlab.com/" };
@@ -450,6 +451,146 @@ describe("SYNC_TO_PL", () => {
 		vi.mocked(browser.tabs.sendMessage as any).mockResolvedValue(null);
 		await call({ type: "SYNC_TO_PL", sourceId: "vanguard" });
 		expect(browser.storage.local.set).not.toHaveBeenCalled();
+	});
+});
+
+describe("SYNC_TO_PL (split mappings)", () => {
+	it("expands a percent split into one entry per leg", async () => {
+		vi.mocked(browser.tabs.query).mockResolvedValueOnce([mockTab] as any);
+		vi.mocked(browser.storage.local.get).mockResolvedValue({
+			plApiKey: "test-key",
+			accounts_vanguard: [{ name: "401k", balance: 10_000, accountId: "v-1" }],
+			mappings_vanguard: {
+				"v-1": {
+					splits: [
+						{ plId: "pl-roth", mode: "percent", value: 60 },
+						{ plId: "pl-trad", mode: "percent", value: 40 },
+					],
+				},
+			},
+		} as any);
+		vi.mocked(browser.tabs.sendMessage as any).mockResolvedValue({
+			results: [],
+		});
+		await call({ type: "SYNC_TO_PL", sourceId: "vanguard" });
+		const sentEntries = vi.mocked(browser.tabs.sendMessage as any).mock
+			.calls[0][1].entries;
+		expect(sentEntries).toEqual([
+			{ plId: "pl-roth", balance: 6000, name: "401k" },
+			{ plId: "pl-trad", balance: 4000, name: "401k" },
+		]);
+	});
+
+	it("uses a remainder leg to absorb what fixed legs leave", async () => {
+		vi.mocked(browser.tabs.query).mockResolvedValueOnce([mockTab] as any);
+		vi.mocked(browser.storage.local.get).mockResolvedValue({
+			plApiKey: "test-key",
+			accounts_vanguard: [{ name: "401k", balance: 10_000, accountId: "v-1" }],
+			mappings_vanguard: {
+				"v-1": {
+					splits: [
+						{ plId: "pl-trad", mode: "fixed", value: 7500 },
+						{ plId: "pl-roth", mode: "remainder" },
+					],
+				},
+			},
+		} as any);
+		vi.mocked(browser.tabs.sendMessage as any).mockResolvedValue({
+			results: [],
+		});
+		await call({ type: "SYNC_TO_PL", sourceId: "vanguard" });
+		const sentEntries = vi.mocked(browser.tabs.sendMessage as any).mock
+			.calls[0][1].entries;
+		expect(sentEntries).toEqual([
+			{ plId: "pl-trad", balance: 7500, name: "401k" },
+			{ plId: "pl-roth", balance: 2500, name: "401k" },
+		]);
+	});
+
+	it("composes a split leg additively with another source mapped to the same PL account", async () => {
+		vi.mocked(browser.tabs.query).mockResolvedValueOnce([mockTab] as any);
+		vi.mocked(browser.storage.local.get).mockResolvedValue({
+			plApiKey: "test-key",
+			// Vanguard's 401k splits 60/40 Roth/Trad.
+			accounts_vanguard: [{ name: "401k", balance: 10_000, accountId: "v-1" }],
+			mappings_vanguard: {
+				"v-1": {
+					splits: [
+						{ plId: "pl-roth", mode: "percent", value: 60 },
+						{ plId: "pl-trad", mode: "percent", value: 40 },
+					],
+				},
+			},
+			// YNAB also tracks a Roth IRA balance and points at the same PL Roth account.
+			accounts_ynab: [{ name: "Roth IRA", balance: 1500, accountId: "y-1" }],
+			mappings_ynab: { "y-1": "pl-roth" },
+		} as any);
+		vi.mocked(browser.tabs.sendMessage as any).mockResolvedValue({
+			results: [],
+		});
+		await call({ type: "SYNC_TO_PL", sourceId: "vanguard" });
+		const sentEntries = vi.mocked(browser.tabs.sendMessage as any).mock
+			.calls[0][1].entries;
+		expect(sentEntries).toEqual([
+			{ plId: "pl-roth", balance: 7500, name: "401k + Roth IRA" },
+			{ plId: "pl-trad", balance: 4000, name: "401k" },
+		]);
+	});
+
+	it("drops split legs targeting the IGNORE sentinel from sync entries", async () => {
+		// User wants 60% Roth, 40% intentionally not synced.
+		vi.mocked(browser.tabs.query).mockResolvedValueOnce([mockTab] as any);
+		vi.mocked(browser.storage.local.get).mockResolvedValue({
+			plApiKey: "test-key",
+			accounts_vanguard: [{ name: "401k", balance: 10_000, accountId: "v-1" }],
+			mappings_vanguard: {
+				"v-1": {
+					splits: [
+						{ plId: "pl-roth", mode: "percent", value: 60 },
+						{ plId: IGNORE_PL_ID, mode: "percent", value: 40 },
+					],
+				},
+			},
+		} as any);
+		vi.mocked(browser.tabs.sendMessage as any).mockResolvedValue({
+			results: [],
+		});
+		await call({ type: "SYNC_TO_PL", sourceId: "vanguard" });
+		const sentEntries = vi.mocked(browser.tabs.sendMessage as any).mock
+			.calls[0][1].entries;
+		expect(sentEntries).toEqual([
+			{ plId: "pl-roth", balance: 6000, name: "401k" },
+		]);
+	});
+
+	it("only pushes split legs whose plId the current source contributes to", async () => {
+		// Vanguard splits to pl-roth + pl-trad. YNAB happens to map something
+		// to pl-checking. We sync vanguard, so pl-checking must NOT appear.
+		vi.mocked(browser.tabs.query).mockResolvedValueOnce([mockTab] as any);
+		vi.mocked(browser.storage.local.get).mockResolvedValue({
+			plApiKey: "test-key",
+			accounts_vanguard: [{ name: "401k", balance: 10_000, accountId: "v-1" }],
+			mappings_vanguard: {
+				"v-1": {
+					splits: [
+						{ plId: "pl-roth", mode: "percent", value: 60 },
+						{ plId: "pl-trad", mode: "percent", value: 40 },
+					],
+				},
+			},
+			accounts_ynab: [{ name: "Checking", balance: 800, accountId: "y-1" }],
+			mappings_ynab: { "y-1": "pl-checking" },
+		} as any);
+		vi.mocked(browser.tabs.sendMessage as any).mockResolvedValue({
+			results: [],
+		});
+		await call({ type: "SYNC_TO_PL", sourceId: "vanguard" });
+		const sentEntries = vi.mocked(browser.tabs.sendMessage as any).mock
+			.calls[0][1].entries;
+		expect(sentEntries.map((e: any) => e.plId).sort()).toEqual([
+			"pl-roth",
+			"pl-trad",
+		]);
 	});
 });
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,3 +1,4 @@
+import { expandToSyncCandidates } from "~/lib/mapping";
 import {
 	getAccounts,
 	getCreds,
@@ -146,28 +147,26 @@ async function handleMessage(msg: BgMessage): Promise<unknown> {
 		const targetPlIds = new Set<string>();
 
 		for (const account of current?.accounts ?? []) {
-			const plId = current?.mappings[getMappingKey(account)];
-
-			if (plId && account.balance !== null) targetPlIds.add(plId);
+			const entry = current?.mappings[getMappingKey(account)];
+			for (const candidate of expandToSyncCandidates(account, entry)) {
+				targetPlIds.add(candidate.plId);
+			}
 		}
 
 		const grouped = new Map<string, SyncEntry>();
 
 		for (const { accounts, mappings } of allSources) {
 			for (const account of accounts) {
-				const plId = mappings[getMappingKey(account)];
-				if (!plId || account.balance === null || !targetPlIds.has(plId))
-					continue;
-				const existing = grouped.get(plId);
-				if (existing) {
-					existing.balance += account.balance;
-					existing.name = `${existing.name} + ${account.name}`;
-				} else {
-					grouped.set(plId, {
-						plId,
-						balance: account.balance,
-						name: account.name,
-					});
+				const entry = mappings[getMappingKey(account)];
+				for (const candidate of expandToSyncCandidates(account, entry)) {
+					if (!targetPlIds.has(candidate.plId)) continue;
+					const existing = grouped.get(candidate.plId);
+					if (existing) {
+						existing.balance += candidate.balance;
+						existing.name = `${existing.name} + ${candidate.name}`;
+					} else {
+						grouped.set(candidate.plId, { ...candidate });
+					}
 				}
 			}
 		}

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -96,7 +96,7 @@ export default function Popup() {
 	const showSettings = view === "settings" || forceSettings;
 
 	return (
-		<div className="flex w-full h-full min-w-115 bg-white text-sm text-gray-900 overflow-hidden">
+		<div className="flex w-full h-full min-w-135 bg-white text-sm text-gray-900 overflow-hidden">
 			<Sidebar
 				plugins={enabledPlugins}
 				activeId={activePlugin?.id ?? ""}

--- a/entrypoints/popup/SourcePanel.test.tsx
+++ b/entrypoints/popup/SourcePanel.test.tsx
@@ -269,4 +269,39 @@ describe("SourcePanel", () => {
 			expect(screen.queryByText("PL not open")).not.toBeInTheDocument(),
 		);
 	});
+
+	it("does not count an all-ignore split as mapped", async () => {
+		// Row exists, with a split that targets only the IGNORE sentinel — no
+		// real PL targets get synced, so the row must not inflate the counter.
+		vi.mocked(browser.storage.local.get).mockResolvedValue({
+			accounts_vanguard: accounts,
+			mappings_vanguard: {
+				IRA: {
+					splits: [{ plId: "__ignore__", mode: "percent", value: 100 }],
+				},
+			},
+		} as any);
+		render(<SourcePanel {...defaults} plAccounts={plAccounts} />);
+		await waitFor(() =>
+			expect(screen.getByText("0 of 1 mapped")).toBeInTheDocument(),
+		);
+	});
+
+	it("counts a split with at least one real PL target as mapped", async () => {
+		vi.mocked(browser.storage.local.get).mockResolvedValue({
+			accounts_vanguard: accounts,
+			mappings_vanguard: {
+				IRA: {
+					splits: [
+						{ plId: "pl-1", mode: "percent", value: 60 },
+						{ plId: "__ignore__", mode: "percent", value: 40 },
+					],
+				},
+			},
+		} as any);
+		render(<SourcePanel {...defaults} plAccounts={plAccounts} />);
+		await waitFor(() =>
+			expect(screen.getByText("1 of 1 mapped")).toBeInTheDocument(),
+		);
+	});
 });

--- a/entrypoints/popup/SourcePanel.tsx
+++ b/entrypoints/popup/SourcePanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { isSplitValid, mappingTargets } from "~/lib/mapping";
 import {
 	getOtherSourceMappings,
 	getSourceState,
@@ -10,6 +11,7 @@ import type {
 	PLMappings,
 	PlAccount,
 	PlSyncState,
+	SplitMapping,
 	SyncResult,
 } from "~/types";
 import AccountList from "./components/AccountList";
@@ -82,10 +84,20 @@ export default function SourcePanel({
 		onRefreshed();
 	};
 
-	const handleMappingChange = async (vKey: string, plId: string) => {
-		const next = { ...mappings, [vKey]: plId };
+	const handleMappingChange = async (
+		vKey: string,
+		entry: string | SplitMapping,
+	) => {
+		const next: PLMappings = { ...mappings, [vKey]: entry };
 
-		if (!plId) delete next[vKey];
+		// Empty string clears the row to "Not mapped". Splits with no legs are
+		// treated the same way to avoid persisting an unsyncable shell.
+		if (
+			entry === "" ||
+			(typeof entry === "object" && entry.splits.length === 0)
+		) {
+			delete next[vKey];
+		}
 
 		setPLMappings(next);
 
@@ -106,9 +118,17 @@ export default function SourcePanel({
 		}
 	};
 
+	// "Mapped" means the row will actually produce a sync entry. An all-ignore
+	// split has truthy `plId`s on every leg but resolves to zero real targets,
+	// so it should not inflate the counter.
 	const mappedCount = accounts.filter(
-		(acc, i) => !!mappings[accountKey(acc, i)],
+		(acc, i) => mappingTargets(mappings[accountKey(acc, i)]).length > 0,
 	).length;
+
+	const hasInvalidSplit = accounts.some((acc, i) => {
+		const entry = mappings[accountKey(acc, i)];
+		return !isSplitValid(acc.balance, entry);
+	});
 
 	return (
 		<div className="flex flex-col flex-1 min-h-0">
@@ -134,6 +154,7 @@ export default function SourcePanel({
 					mappedCount={mappedCount}
 					totalCount={accounts.length}
 					plAccountsLoaded={plAccounts.length > 0}
+					hasInvalidSplit={hasInvalidSplit}
 					plSync={plSync}
 					onSync={handleSync}
 				/>

--- a/entrypoints/popup/components/AccountList.tsx
+++ b/entrypoints/popup/components/AccountList.tsx
@@ -1,16 +1,17 @@
+import { isSplitMapping } from "~/lib/mapping";
 import { PLUGINS, type SourcePlugin } from "~/plugins";
-import type { Account, PlAccount } from "~/types";
+import type { Account, PLMappings, PlAccount, SplitMapping } from "~/types";
 import { accountKey } from "../utils";
 import AccountRow from "./AccountRow";
 
 type Props = {
 	plugin: SourcePlugin;
 	accounts: Account[];
-	mappings: Record<string, string>;
+	mappings: PLMappings;
 	plAccounts: PlAccount[];
 	otherSourceMappings?: Record<string, string[]>;
 	sourceError: string | null;
-	onMappingChange: (key: string, plId: string) => void;
+	onMappingChange: (key: string, entry: string | SplitMapping) => void;
 };
 
 const pluginName = (id: string) =>
@@ -56,7 +57,8 @@ export default function AccountList({
 						{accounts.map((acc, i) => {
 							const key = accountKey(acc, i);
 
-							const mappedPlId = mappings[key] ?? "";
+							const entry = mappings[key];
+							const mappedPlId = entry && !isSplitMapping(entry) ? entry : "";
 
 							const otherSources = mappedPlId
 								? (otherSourceMappings?.[mappedPlId] ?? []).map(pluginName)
@@ -67,6 +69,7 @@ export default function AccountList({
 									key={key}
 									accountKey={key}
 									account={acc}
+									mapping={entry}
 									mapped={mappedPlId}
 									plAccounts={plAccounts}
 									otherSources={otherSources}

--- a/entrypoints/popup/components/AccountRow.test.tsx
+++ b/entrypoints/popup/components/AccountRow.test.tsx
@@ -199,6 +199,83 @@ describe("AccountRow", () => {
 		expect(screen.queryByText(/also from/)).not.toBeInTheDocument();
 	});
 
+	it("offers a 'Split into multiple' affordance when PL accounts are loaded and row is single-mapped", () => {
+		render(
+			<AccountRow
+				accountKey="IRA"
+				account={account}
+				mapped="pl-1"
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+			/>,
+		);
+		expect(
+			screen.getByRole("button", { name: /split into multiple/i }),
+		).toBeInTheDocument();
+	});
+
+	it("does not offer the split affordance until PL accounts are loaded", () => {
+		render(
+			<AccountRow
+				accountKey="IRA"
+				account={account}
+				mapped=""
+				plAccounts={[]}
+				onChange={vi.fn()}
+			/>,
+		);
+		expect(
+			screen.queryByRole("button", { name: /split into multiple/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("seeds a split with the current mapping when the user clicks split", () => {
+		const onChange = vi.fn();
+		render(
+			<AccountRow
+				accountKey="IRA"
+				account={account}
+				mapped="pl-1"
+				plAccounts={plAccounts}
+				onChange={onChange}
+			/>,
+		);
+		fireEvent.click(
+			screen.getByRole("button", { name: /split into multiple/i }),
+		);
+		expect(onChange).toHaveBeenCalledWith("IRA", {
+			splits: [{ plId: "pl-1", mode: "percent", value: 100 }],
+		});
+	});
+
+	it("renders the split editor instead of the select when mapping is a SplitMapping", () => {
+		render(
+			<AccountRow
+				accountKey="IRA"
+				account={account}
+				mapping={{
+					splits: [
+						{ plId: "pl-1", mode: "percent", value: 60 },
+						{ plId: "pl-2", mode: "remainder" },
+					],
+				}}
+				mapped=""
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+			/>,
+		);
+		// The flat single-select is gone (would have included a "Not mapped" option).
+		expect(
+			screen.queryByRole("option", { name: "Not mapped" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("combobox", { name: /split leg 1 pl account/i }),
+		).toHaveValue("pl-1");
+		expect(
+			screen.getByRole("combobox", { name: /split leg 2 pl account/i }),
+		).toHaveValue("pl-2");
+	});
+
 	it("pins behavior for a stale mapping referencing a deleted PL account", () => {
 		// User deleted 'pl-deleted' in ProjectionLab but the mapping is still in storage.
 		// Pins the current (silent) behavior so a future change to surface a warning

--- a/entrypoints/popup/components/AccountRow.tsx
+++ b/entrypoints/popup/components/AccountRow.tsx
@@ -1,33 +1,79 @@
-import type { Account, PlAccount } from "~/types";
+import { isSplitMapping } from "~/lib/mapping";
+import type { Account, PlAccount, SplitMapping } from "~/types";
 import { fmt } from "../utils";
+import SplitEditor from "./SplitEditor";
 
 type Props = {
 	accountKey: string;
 	account: Account;
+	mapping?: string | SplitMapping;
 	mapped: string;
 	plAccounts: PlAccount[];
 	otherSources?: string[];
-	onChange: (key: string, plId: string) => void;
+	onChange: (key: string, entry: string | SplitMapping) => void;
 };
 
 export default function AccountRow({
 	accountKey,
 	account,
+	mapping,
 	mapped,
 	plAccounts,
 	otherSources,
 	onChange,
 }: Props) {
-	const showOverlapHint = mapped && otherSources && otherSources.length > 0;
+	const isSplit = isSplitMapping(mapping);
+	const showOverlapHint =
+		!isSplit && mapped && otherSources && otherSources.length > 0;
+
+	const startSplit = () => {
+		const seedLeg: SplitMapping["splits"][number] = mapped
+			? { plId: mapped, mode: "percent", value: 100 }
+			: { plId: "", mode: "percent", value: 100 };
+		onChange(accountKey, { splits: [seedLeg] });
+	};
+
+	const endSplit = () => {
+		// Cancelling a split clears the mapping back to "Not mapped".
+		onChange(accountKey, "");
+	};
+
+	if (isSplit) {
+		return (
+			<div className="py-2.5 space-y-2">
+				<div className="flex items-baseline justify-between gap-2">
+					<div className="min-w-0">
+						<div className="truncate font-medium text-gray-800 text-xs">
+							{account.name}
+						</div>
+						<div className="text-gray-400 text-[11px]">
+							{fmt(account.balance)}
+						</div>
+					</div>
+					<span className="text-[10px] text-indigo-600 font-medium uppercase tracking-wide shrink-0">
+						Split
+					</span>
+				</div>
+				<SplitEditor
+					account={account}
+					mapping={mapping}
+					plAccounts={plAccounts}
+					onChange={(next) => onChange(accountKey, next)}
+					onCancel={endSplit}
+				/>
+			</div>
+		);
+	}
+
 	return (
-		<div className="grid grid-cols-[1fr_auto_152px] gap-2 items-center py-2">
+		<div className="grid grid-cols-[1fr_auto_152px] gap-2 items-start py-2">
 			<div className="min-w-0">
 				<div className="truncate font-medium text-gray-800 text-xs">
 					{account.name}
 				</div>
 				<div className="text-gray-400 text-[11px]">{fmt(account.balance)}</div>
 			</div>
-			<span className="text-gray-300 text-xs">→</span>
+			<span className="text-gray-300 text-xs pt-1">→</span>
 			<div className="min-w-0">
 				<select
 					value={mapped}
@@ -44,6 +90,15 @@ export default function AccountRow({
 						</option>
 					))}
 				</select>
+				{plAccounts.length > 0 && (
+					<button
+						type="button"
+						onClick={startSplit}
+						className="text-[10px] text-indigo-600 hover:text-indigo-700 mt-1 leading-tight"
+					>
+						Split into multiple
+					</button>
+				)}
 				{showOverlapHint && (
 					<div
 						className="text-[10px] text-amber-600 mt-1 leading-tight"

--- a/entrypoints/popup/components/SplitEditor.test.tsx
+++ b/entrypoints/popup/components/SplitEditor.test.tsx
@@ -125,6 +125,41 @@ describe("SplitEditor", () => {
 		expect(node.className).toMatch(/text-red/);
 	});
 
+	it("shows over-allocation in red when fixed legs exceed total despite a remainder leg", () => {
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([
+					{ plId: "pl-trad", mode: "fixed", value: 12_000 },
+					{ plId: "pl-roth", mode: "remainder" },
+				])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		const node = screen.getByText(/Over-allocated by \$2,000/);
+		expect(node).toBeInTheDocument();
+		expect(node.className).toMatch(/text-red/);
+	});
+
+	it("does not warn for a valid remainder split on a negative (liability) balance", () => {
+		render(
+			<SplitEditor
+				account={{ name: "Card", balance: -2000, accountId: "v-2" }}
+				mapping={splitWith([
+					{ plId: "pl-trad", mode: "percent", value: 50 },
+					{ plId: "pl-roth", mode: "remainder" },
+				])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		expect(screen.queryByText(/Over-allocated/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/unallocated/)).not.toBeInTheDocument();
+	});
+
 	it("renders the resolved dollar amount for a remainder leg", () => {
 		render(
 			<SplitEditor

--- a/entrypoints/popup/components/SplitEditor.test.tsx
+++ b/entrypoints/popup/components/SplitEditor.test.tsx
@@ -1,0 +1,326 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { IGNORE_PL_ID } from "~/lib/mapping";
+import type { Account, PlAccount, SplitMapping } from "~/types";
+import SplitEditor from "./SplitEditor";
+
+const account: Account = { name: "401k", balance: 10_000, accountId: "v-1" };
+const plAccounts: PlAccount[] = [
+	{ id: "pl-roth", name: "Roth IRA" },
+	{ id: "pl-trad", name: "Traditional IRA" },
+];
+
+const splitWith = (legs: SplitMapping["splits"]): SplitMapping => ({
+	splits: legs,
+});
+
+describe("SplitEditor", () => {
+	it("shows one row per leg", () => {
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([
+					{ plId: "pl-roth", mode: "percent", value: 60 },
+					{ plId: "pl-trad", mode: "percent", value: 40 },
+				])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		expect(
+			screen.getByRole("combobox", { name: /split leg 1 pl account/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("combobox", { name: /split leg 2 pl account/i }),
+		).toBeInTheDocument();
+	});
+
+	it("calls onChange with an extra leg when 'Add leg' is clicked", () => {
+		const onChange = vi.fn();
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([{ plId: "pl-roth", mode: "percent", value: 100 }])}
+				plAccounts={plAccounts}
+				onChange={onChange}
+				onCancel={vi.fn()}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: /add target/i }));
+		expect(onChange).toHaveBeenCalledWith({
+			splits: [
+				{ plId: "pl-roth", mode: "percent", value: 100 },
+				{ plId: "", mode: "percent", value: 0 },
+			],
+		});
+	});
+
+	it("calls onChange with the leg removed when its × is clicked", () => {
+		const onChange = vi.fn();
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([
+					{ plId: "pl-roth", mode: "percent", value: 60 },
+					{ plId: "pl-trad", mode: "percent", value: 40 },
+				])}
+				plAccounts={plAccounts}
+				onChange={onChange}
+				onCancel={vi.fn()}
+			/>,
+		);
+		fireEvent.click(
+			screen.getByRole("button", { name: /remove split leg 1/i }),
+		);
+		expect(onChange).toHaveBeenCalledWith({
+			splits: [{ plId: "pl-trad", mode: "percent", value: 40 }],
+		});
+	});
+
+	it("warns when percent legs do not sum to 100", () => {
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([
+					{ plId: "pl-roth", mode: "percent", value: 60 },
+					{ plId: "pl-trad", mode: "percent", value: 30 },
+				])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText(/Percentages total 90.0%/)).toBeInTheDocument();
+	});
+
+	it("does not warn about percent total when a remainder leg is present", () => {
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([
+					{ plId: "pl-roth", mode: "percent", value: 60 },
+					{ plId: "pl-trad", mode: "remainder" },
+				])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		expect(screen.queryByText(/Percentages total/)).toBeNull();
+	});
+
+	it("shows over-allocation in red when fixed legs exceed total", () => {
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([{ plId: "pl-roth", mode: "fixed", value: 12_000 }])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		const node = screen.getByText(/Over-allocated by/);
+		expect(node).toBeInTheDocument();
+		expect(node.className).toMatch(/text-red/);
+	});
+
+	it("renders the resolved dollar amount for a remainder leg", () => {
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([
+					{ plId: "pl-trad", mode: "fixed", value: 7500 },
+					{ plId: "pl-roth", mode: "remainder" },
+				])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		// Each leg shows its computed amount as "= $X"; remainder leg = $2,500.
+		expect(screen.getByText(/= \$2,500/)).toBeInTheDocument();
+	});
+
+	it("uses a 1% stepper increment for percent legs", () => {
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([{ plId: "pl-roth", mode: "percent", value: 60 }])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		const input = screen.getByRole("spinbutton", {
+			name: /split leg 1 value/i,
+		});
+		expect(input).toHaveAttribute("step", "1");
+	});
+
+	it("uses a $100 stepper increment for fixed legs", () => {
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([{ plId: "pl-roth", mode: "fixed", value: 5000 }])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		const input = screen.getByRole("spinbutton", {
+			name: /split leg 1 value/i,
+		});
+		expect(input).toHaveAttribute("step", "100");
+	});
+
+	it("rounds typed percent values to 0.1 precision", () => {
+		const onChange = vi.fn();
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([{ plId: "pl-roth", mode: "percent", value: 60 }])}
+				plAccounts={plAccounts}
+				onChange={onChange}
+				onCancel={vi.fn()}
+			/>,
+		);
+		const input = screen.getByRole("spinbutton", {
+			name: /split leg 1 value/i,
+		});
+		fireEvent.change(input, { target: { value: "60.55" } });
+		expect(onChange).toHaveBeenCalledWith({
+			splits: [{ plId: "pl-roth", mode: "percent", value: 60.6 }],
+		});
+	});
+
+	it("preserves a single-decimal percent value as typed", () => {
+		const onChange = vi.fn();
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([{ plId: "pl-roth", mode: "percent", value: 60 }])}
+				plAccounts={plAccounts}
+				onChange={onChange}
+				onCancel={vi.fn()}
+			/>,
+		);
+		fireEvent.change(
+			screen.getByRole("spinbutton", { name: /split leg 1 value/i }),
+			{ target: { value: "60.5" } },
+		);
+		expect(onChange).toHaveBeenCalledWith({
+			splits: [{ plId: "pl-roth", mode: "percent", value: 60.5 }],
+		});
+	});
+
+	it("does not commit 0 when the user clears the field mid-edit", () => {
+		const onChange = vi.fn();
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([{ plId: "pl-roth", mode: "percent", value: 60 }])}
+				plAccounts={plAccounts}
+				onChange={onChange}
+				onCancel={vi.fn()}
+			/>,
+		);
+		const input = screen.getByRole("spinbutton", {
+			name: /split leg 1 value/i,
+		});
+		fireEvent.focus(input);
+		fireEvent.change(input, { target: { value: "" } });
+		// Empty doesn't parse — no onChange call with 0 mid-edit.
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("commits 0 on blur if the user leaves the field empty", () => {
+		// Blur normalizes a non-parsable draft to 0 so storage doesn't keep
+		// a NaN-shaped value.
+		const onChange = vi.fn();
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([{ plId: "pl-roth", mode: "percent", value: 60 }])}
+				plAccounts={plAccounts}
+				onChange={onChange}
+				onCancel={vi.fn()}
+			/>,
+		);
+		const input = screen.getByRole("spinbutton", {
+			name: /split leg 1 value/i,
+		});
+		fireEvent.focus(input);
+		fireEvent.change(input, { target: { value: "" } });
+		fireEvent.blur(input);
+		expect(onChange).toHaveBeenLastCalledWith({
+			splits: [{ plId: "pl-roth", mode: "percent", value: 0 }],
+		});
+	});
+
+	it("does not round fixed-leg input values", () => {
+		const onChange = vi.fn();
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([{ plId: "pl-roth", mode: "fixed", value: 5000 }])}
+				plAccounts={plAccounts}
+				onChange={onChange}
+				onCancel={vi.fn()}
+			/>,
+		);
+		fireEvent.change(
+			screen.getByRole("spinbutton", { name: /split leg 1 value/i }),
+			{ target: { value: "5123.45" } },
+		);
+		expect(onChange).toHaveBeenCalledWith({
+			splits: [{ plId: "pl-roth", mode: "fixed", value: 5123.45 }],
+		});
+	});
+
+	it("offers a 'Don't sync this portion' option in each leg's PL select", () => {
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([{ plId: "pl-roth", mode: "percent", value: 100 }])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		expect(
+			screen.getByRole("option", { name: /Don't sync this portion/i }),
+		).toBeInTheDocument();
+	});
+
+	it("annotates a leg targeting IGNORE_PL_ID as (ignored)", () => {
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([
+					{ plId: "pl-roth", mode: "percent", value: 60 },
+					{ plId: IGNORE_PL_ID, mode: "percent", value: 40 },
+				])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText(/\(ignored\)/i)).toBeInTheDocument();
+	});
+
+	it("invokes onCancel when 'Cancel split' is clicked", () => {
+		const onCancel = vi.fn();
+		render(
+			<SplitEditor
+				account={account}
+				mapping={splitWith([{ plId: "pl-roth", mode: "percent", value: 100 }])}
+				plAccounts={plAccounts}
+				onChange={vi.fn()}
+				onCancel={onCancel}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: /cancel split/i }));
+		expect(onCancel).toHaveBeenCalled();
+	});
+});

--- a/entrypoints/popup/components/SplitEditor.tsx
+++ b/entrypoints/popup/components/SplitEditor.tsx
@@ -135,10 +135,20 @@ export default function SplitEditor({
 		mapping.splits.some((l) => l.mode === "percent") &&
 		remainderCount === 0 &&
 		Math.abs(percentTotal - 100) > SPLIT_PERCENT_TOLERANCE;
+	const remainderOverAllocated =
+		remainderCount > 0 &&
+		(total >= 0
+			? remainderShare < -SPLIT_DOLLAR_TOLERANCE
+			: remainderShare > SPLIT_DOLLAR_TOLERANCE);
 	const overAllocated =
-		remainderCount === 0 && unallocated < -SPLIT_DOLLAR_TOLERANCE;
+		remainderOverAllocated ||
+		(remainderCount === 0 && unallocated < -SPLIT_DOLLAR_TOLERANCE);
 	const underAllocated =
 		remainderCount === 0 && unallocated > SPLIT_DOLLAR_TOLERANCE;
+	const overAllocatedBy =
+		remainderCount > 0
+			? Math.abs(remainderShare * remainderCount)
+			: Math.abs(unallocated);
 
 	return (
 		<div className="border border-indigo-100 bg-indigo-50/40 rounded-md">
@@ -246,7 +256,7 @@ export default function SplitEditor({
 					</span>
 				) : overAllocated ? (
 					<span className="text-red-500">
-						Over-allocated by {fmt(Math.abs(unallocated))}
+						Over-allocated by {fmt(overAllocatedBy)}
 					</span>
 				) : underAllocated ? (
 					<span className="text-amber-600">{fmt(unallocated)} unallocated</span>

--- a/entrypoints/popup/components/SplitEditor.tsx
+++ b/entrypoints/popup/components/SplitEditor.tsx
@@ -1,0 +1,265 @@
+import { useEffect, useState } from "react";
+import {
+	IGNORE_PL_ID,
+	isIgnoreTarget,
+	SPLIT_DOLLAR_TOLERANCE,
+	SPLIT_PERCENT_TOLERANCE,
+	summarizeSplit,
+	withLegPlId,
+	withLegValue,
+} from "~/lib/mapping";
+import type { Account, PlAccount, SplitLeg, SplitMapping } from "~/types";
+import { fmt } from "../utils";
+
+type Props = {
+	account: Account;
+	mapping: SplitMapping;
+	plAccounts: PlAccount[];
+	onChange: (next: SplitMapping) => void;
+	onCancel: () => void;
+};
+
+const MODES: { value: SplitLeg["mode"]; label: string }[] = [
+	{ value: "percent", label: "%" },
+	{ value: "fixed", label: "$" },
+	{ value: "remainder", label: "rest" },
+];
+
+function setLegMode(leg: SplitLeg, mode: SplitLeg["mode"]): SplitLeg {
+	if (mode === "remainder") return { plId: leg.plId, mode: "remainder" };
+	const value = leg.mode === "remainder" ? 0 : leg.value;
+	return { plId: leg.plId, mode, value };
+}
+
+/**
+ * Number input that keeps a local string draft while the user is editing.
+ * Without this, `parseFloat(e.target.value) || 0` snaps the displayed value
+ * back to `0` when the user clears the field, types a leading `-`, or leaves
+ * a trailing decimal (e.g. `"60."`). The committed numeric value still flows
+ * up live on each parsable change, so the editor's status pill stays
+ * responsive.
+ */
+function LegValueInput({
+	value,
+	step,
+	roundToTenths,
+	ariaLabel,
+	onChange,
+}: {
+	value: number;
+	step: number;
+	roundToTenths: boolean;
+	ariaLabel: string;
+	onChange: (next: number) => void;
+}) {
+	const [focused, setFocused] = useState(false);
+	const [draft, setDraft] = useState<string>(() => String(value));
+
+	// Sync from the canonical numeric value when the user isn't actively
+	// editing. Avoids stomping mid-edit while still picking up programmatic
+	// changes (e.g. a mode toggle that resets value to 0).
+	useEffect(() => {
+		if (!focused) setDraft(String(value));
+	}, [value, focused]);
+
+	const normalize = (raw: number): number =>
+		roundToTenths ? Math.round(raw * 10) / 10 : raw;
+
+	return (
+		<input
+			aria-label={ariaLabel}
+			type="number"
+			inputMode="decimal"
+			value={draft}
+			step={step}
+			min={0}
+			onFocus={() => setFocused(true)}
+			onBlur={() => {
+				setFocused(false);
+				const parsed = Number.parseFloat(draft);
+				const next = Number.isFinite(parsed) ? normalize(parsed) : 0;
+				onChange(next);
+				setDraft(String(next));
+			}}
+			onChange={(e) => {
+				setDraft(e.target.value);
+				const parsed = Number.parseFloat(e.target.value);
+				// Commit live whenever the draft parses cleanly so the leg's
+				// "= $X" preview and the status pill update as the user types.
+				// Drafts like "-", "" or "60." don't commit, leaving the
+				// previous numeric value in place.
+				if (Number.isFinite(parsed)) onChange(normalize(parsed));
+			}}
+			className="w-20 text-right text-xs border border-gray-200 rounded-md px-2 py-1 bg-white text-gray-800 tabular-nums focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:border-indigo-400"
+		/>
+	);
+}
+
+export default function SplitEditor({
+	account,
+	mapping,
+	plAccounts,
+	onChange,
+	onCancel,
+}: Props) {
+	const total = account.balance;
+	const {
+		percentTotal,
+		remainderCount,
+		remainderShare,
+		allocated,
+		unallocated,
+	} = summarizeSplit(total, mapping.splits);
+
+	const updateLeg = (i: number, leg: SplitLeg) => {
+		const next = [...mapping.splits];
+		next[i] = leg;
+		onChange({ splits: next });
+	};
+
+	const removeLeg = (i: number) =>
+		onChange({ splits: mapping.splits.filter((_, j) => j !== i) });
+
+	const addLeg = () =>
+		onChange({
+			splits: [...mapping.splits, { plId: "", mode: "percent", value: 0 }],
+		});
+
+	const legAmount = (leg: SplitLeg): number => {
+		if (leg.mode === "fixed") return leg.value;
+		if (leg.mode === "percent") return (total * leg.value) / 100;
+		return remainderShare;
+	};
+
+	const percentInvalid =
+		mapping.splits.some((l) => l.mode === "percent") &&
+		remainderCount === 0 &&
+		Math.abs(percentTotal - 100) > SPLIT_PERCENT_TOLERANCE;
+	const overAllocated =
+		remainderCount === 0 && unallocated < -SPLIT_DOLLAR_TOLERANCE;
+	const underAllocated =
+		remainderCount === 0 && unallocated > SPLIT_DOLLAR_TOLERANCE;
+
+	return (
+		<div className="border border-indigo-100 bg-indigo-50/40 rounded-md">
+			<ul className="divide-y divide-indigo-100">
+				{mapping.splits.map((leg, i) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: split legs have no stable id; positional reordering not supported
+					<li key={i} className="px-2.5 py-2 space-y-1.5">
+						<div className="flex items-center gap-2">
+							<select
+								aria-label={`Split leg ${i + 1} PL account`}
+								value={leg.plId}
+								onChange={(e) => updateLeg(i, withLegPlId(leg, e.target.value))}
+								className="flex-1 min-w-0 text-xs border border-gray-200 rounded-md px-2 py-1.5 bg-white text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:border-indigo-400"
+							>
+								<option value="">Pick PL account…</option>
+								<option value={IGNORE_PL_ID}>
+									— Don't sync this portion —
+								</option>
+								{plAccounts.map((pla) => (
+									<option key={pla.id} value={pla.id}>
+										{pla.name}
+									</option>
+								))}
+							</select>
+							<button
+								type="button"
+								onClick={() => removeLeg(i)}
+								aria-label={`Remove split leg ${i + 1}`}
+								className="text-gray-400 hover:text-red-500 text-base leading-none px-1"
+							>
+								×
+							</button>
+						</div>
+
+						<div className="flex items-center justify-between gap-2">
+							<fieldset className="inline-flex rounded-md border border-gray-200 overflow-hidden bg-white p-0 m-0">
+								<legend className="sr-only">{`Split leg ${i + 1} mode`}</legend>
+								{MODES.map((m) => {
+									const active = leg.mode === m.value;
+									return (
+										<button
+											type="button"
+											key={m.value}
+											onClick={() => updateLeg(i, setLegMode(leg, m.value))}
+											aria-pressed={active}
+											className={`px-2 py-1 text-[11px] font-medium transition-colors ${
+												active
+													? "bg-indigo-500 text-white"
+													: "text-gray-600 hover:bg-gray-50"
+											}`}
+										>
+											{m.label}
+										</button>
+									);
+								})}
+							</fieldset>
+
+							{leg.mode !== "remainder" && (
+								<div className="flex items-center gap-1">
+									<LegValueInput
+										ariaLabel={`Split leg ${i + 1} value`}
+										value={leg.value}
+										step={leg.mode === "percent" ? 1 : 100}
+										roundToTenths={leg.mode === "percent"}
+										onChange={(next) => updateLeg(i, withLegValue(leg, next))}
+									/>
+									<span className="text-[11px] text-gray-400 w-3">
+										{leg.mode === "percent" ? "%" : "$"}
+									</span>
+								</div>
+							)}
+
+							<span className="text-[11px] tabular-nums shrink-0 ml-auto">
+								<span className="text-gray-500">= {fmt(legAmount(leg))}</span>
+								{isIgnoreTarget(leg.plId) && (
+									<span className="text-gray-400 ml-1">(ignored)</span>
+								)}
+							</span>
+						</div>
+					</li>
+				))}
+			</ul>
+
+			<div className="flex items-center justify-between px-2.5 py-1.5 border-t border-indigo-100 bg-white/60">
+				<button
+					type="button"
+					onClick={addLeg}
+					className="text-[11px] text-indigo-600 hover:text-indigo-700 font-medium"
+				>
+					+ Add target
+				</button>
+				<button
+					type="button"
+					onClick={onCancel}
+					className="text-[11px] text-gray-400 hover:text-gray-600"
+				>
+					Cancel split
+				</button>
+			</div>
+
+			<div className="px-2.5 py-1.5 border-t border-indigo-100 text-[11px] tabular-nums leading-tight bg-white/60 rounded-b-md">
+				{percentInvalid ? (
+					<span className="text-amber-600">
+						Percentages total {percentTotal.toFixed(1)}% — should be 100%
+					</span>
+				) : overAllocated ? (
+					<span className="text-red-500">
+						Over-allocated by {fmt(Math.abs(unallocated))}
+					</span>
+				) : underAllocated ? (
+					<span className="text-amber-600">{fmt(unallocated)} unallocated</span>
+				) : remainderCount > 1 ? (
+					<span className="text-amber-600">
+						{remainderCount} "rest" legs share the remainder equally
+					</span>
+				) : (
+					<span className="text-gray-500">
+						Total: {fmt(allocated)} of {fmt(total)}
+					</span>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/entrypoints/popup/components/SyncFooter.test.tsx
+++ b/entrypoints/popup/components/SyncFooter.test.tsx
@@ -238,4 +238,54 @@ describe("SyncFooter", () => {
 		expect(screen.getByText("IRA")).toBeInTheDocument();
 		expect(screen.getByText(/401k: err/)).toBeInTheDocument();
 	});
+
+	it("disables the sync button when hasInvalidSplit is true", () => {
+		render(
+			<SyncFooter
+				mappedCount={2}
+				totalCount={2}
+				plAccountsLoaded={true}
+				hasInvalidSplit={true}
+				plSync={{ status: "idle" }}
+				onSync={vi.fn()}
+			/>,
+		);
+		expect(
+			screen.getByRole("button", { name: /sync to projectionlab/i }),
+		).toBeDisabled();
+	});
+
+	it("shows a 'Fix split allocation' hint when hasInvalidSplit is true", () => {
+		render(
+			<SyncFooter
+				mappedCount={2}
+				totalCount={2}
+				plAccountsLoaded={true}
+				hasInvalidSplit={true}
+				plSync={{ status: "idle" }}
+				onSync={vi.fn()}
+			/>,
+		);
+		expect(
+			screen.getByText(/Fix split allocation to enable sync/i),
+		).toBeInTheDocument();
+	});
+
+	it("does not call onSync when clicked while a split is invalid", () => {
+		const onSync = vi.fn();
+		render(
+			<SyncFooter
+				mappedCount={2}
+				totalCount={2}
+				plAccountsLoaded={true}
+				hasInvalidSplit={true}
+				plSync={{ status: "idle" }}
+				onSync={onSync}
+			/>,
+		);
+		fireEvent.click(
+			screen.getByRole("button", { name: /sync to projectionlab/i }),
+		);
+		expect(onSync).not.toHaveBeenCalled();
+	});
 });

--- a/entrypoints/popup/components/SyncFooter.tsx
+++ b/entrypoints/popup/components/SyncFooter.tsx
@@ -4,6 +4,7 @@ type Props = {
 	mappedCount: number;
 	totalCount: number;
 	plAccountsLoaded: boolean;
+	hasInvalidSplit?: boolean;
 	plSync: PlSyncState;
 	onSync: () => void;
 };
@@ -12,11 +13,15 @@ export default function SyncFooter({
 	mappedCount,
 	totalCount,
 	plAccountsLoaded,
+	hasInvalidSplit = false,
 	plSync,
 	onSync,
 }: Props) {
 	const canSync =
-		mappedCount > 0 && plAccountsLoaded && plSync.status !== "syncing";
+		mappedCount > 0 &&
+		plAccountsLoaded &&
+		!hasInvalidSplit &&
+		plSync.status !== "syncing";
 
 	return (
 		<div className="px-4 pb-4 pt-2 border-t border-gray-100 space-y-2">
@@ -24,11 +29,15 @@ export default function SyncFooter({
 				<span className="text-[11px] text-gray-400">
 					{mappedCount} of {totalCount} mapped
 				</span>
-				{!plAccountsLoaded && (
+				{!plAccountsLoaded ? (
 					<span className="text-[11px] text-amber-500">
 						Load PL accounts in Settings
 					</span>
-				)}
+				) : hasInvalidSplit ? (
+					<span className="text-[11px] text-amber-600">
+						Fix split allocation to enable sync
+					</span>
+				) : null}
 			</div>
 			<button
 				type="button"

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -6,7 +6,7 @@
     <title>ProjectionLab Sync</title>
     <link href="@/assets/tailwind.css" rel="stylesheet" />
   </head>
-  <body style="width: 460px; height: 480px">
+  <body style="width: 540px; height: 480px">
     <div id="root" style="width: 100%; height: 100%"></div>
     <script type="module" src="./main.tsx"></script>
   </body>

--- a/lib/mapping.test.ts
+++ b/lib/mapping.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it } from "vitest";
+import type { Account, SplitMapping } from "~/types";
+import {
+	expandToSyncCandidates,
+	IGNORE_PL_ID,
+	isSplitMapping,
+	isSplitValid,
+	mappingTargets,
+	summarizeSplit,
+	withLegPlId,
+	withLegValue,
+} from "./mapping";
+
+const acc = (balance: number | null = 1000): Account => ({
+	name: "401k",
+	balance: balance as number,
+	accountId: "a-1",
+});
+
+describe("isSplitMapping", () => {
+	it("returns false for plain string mappings", () => {
+		expect(isSplitMapping("pl-1")).toBe(false);
+	});
+
+	it("returns false for undefined", () => {
+		expect(isSplitMapping(undefined)).toBe(false);
+	});
+
+	it("returns true for an object with a splits array", () => {
+		expect(isSplitMapping({ splits: [] })).toBe(true);
+	});
+
+	it("returns false for an object whose splits field is not an array", () => {
+		// Defense against a corrupt or partially-migrated stored mapping.
+		expect(isSplitMapping({ splits: 42 } as never)).toBe(false);
+		expect(isSplitMapping({ splits: null } as never)).toBe(false);
+	});
+});
+
+describe("summarizeSplit", () => {
+	it("returns all-zero rollup for an empty split", () => {
+		expect(summarizeSplit(1000, [])).toEqual({
+			fixedSum: 0,
+			percentSum: 0,
+			percentTotal: 0,
+			remainderCount: 0,
+			remainderShare: 0,
+			allocated: 0,
+			unallocated: 1000,
+		});
+	});
+
+	it("rolls up percent legs into dollars and a separate percent total", () => {
+		const s = summarizeSplit(10_000, [
+			{ plId: "a", mode: "percent", value: 60 },
+			{ plId: "b", mode: "percent", value: 40 },
+		]);
+		expect(s.percentSum).toBe(10_000);
+		expect(s.percentTotal).toBe(100);
+		expect(s.allocated).toBe(10_000);
+		expect(s.unallocated).toBe(0);
+	});
+
+	it("splits the remainder equally across N remainder legs", () => {
+		const s = summarizeSplit(6000, [
+			{ plId: "a", mode: "fixed", value: 1000 },
+			{ plId: "b", mode: "remainder" },
+			{ plId: "c", mode: "remainder" },
+		]);
+		expect(s.remainderShare).toBe(2500);
+		expect(s.remainderCount).toBe(2);
+		expect(s.allocated).toBe(6000);
+		expect(s.unallocated).toBe(0);
+	});
+
+	it("reports negative unallocated when fixed/percent over-allocate", () => {
+		const s = summarizeSplit(1000, [{ plId: "a", mode: "fixed", value: 1500 }]);
+		expect(s.allocated).toBe(1500);
+		expect(s.unallocated).toBe(-500);
+	});
+});
+
+describe("withLegPlId / withLegValue", () => {
+	it("preserves the discriminant when changing plId on a percent leg", () => {
+		const next = withLegPlId({ plId: "a", mode: "percent", value: 60 }, "b");
+		expect(next).toEqual({ plId: "b", mode: "percent", value: 60 });
+	});
+
+	it("does not introduce a value field when setting plId on a remainder leg", () => {
+		const next = withLegPlId({ plId: "a", mode: "remainder" }, "b");
+		expect(next).toEqual({ plId: "b", mode: "remainder" });
+		expect("value" in next).toBe(false);
+	});
+
+	it("updates value on a fixed leg without altering plId or mode", () => {
+		const next = withLegValue({ plId: "a", mode: "fixed", value: 500 }, 750);
+		expect(next).toEqual({ plId: "a", mode: "fixed", value: 750 });
+	});
+
+	it("is a no-op on remainder legs (no value to set)", () => {
+		const leg = { plId: "a", mode: "remainder" } as const;
+		expect(withLegValue(leg, 999)).toBe(leg);
+	});
+});
+
+describe("mappingTargets", () => {
+	it("returns one target for a plain mapping", () => {
+		expect(mappingTargets("pl-1")).toEqual(["pl-1"]);
+	});
+
+	it("returns every leg's plId for a split mapping", () => {
+		const m: SplitMapping = {
+			splits: [
+				{ plId: "pl-roth", mode: "percent", value: 60 },
+				{ plId: "pl-trad", mode: "remainder" },
+			],
+		};
+		expect(mappingTargets(m)).toEqual(["pl-roth", "pl-trad"]);
+	});
+
+	it("returns empty for undefined", () => {
+		expect(mappingTargets(undefined)).toEqual([]);
+	});
+
+	it("excludes IGNORE_PL_ID legs from the target list", () => {
+		const m: SplitMapping = {
+			splits: [
+				{ plId: "pl-roth", mode: "percent", value: 60 },
+				{ plId: IGNORE_PL_ID, mode: "percent", value: 40 },
+			],
+		};
+		expect(mappingTargets(m)).toEqual(["pl-roth"]);
+	});
+});
+
+describe("isSplitValid", () => {
+	it("treats plain string mappings as always valid", () => {
+		expect(isSplitValid(1000, "pl-1")).toBe(true);
+	});
+
+	it("rejects splits with zero legs", () => {
+		expect(isSplitValid(1000, { splits: [] })).toBe(false);
+	});
+
+	it("rejects splits with any leg missing a plId", () => {
+		expect(
+			isSplitValid(1000, {
+				splits: [
+					{ plId: "pl-roth", mode: "percent", value: 60 },
+					{ plId: "", mode: "percent", value: 40 },
+				],
+			}),
+		).toBe(false);
+	});
+
+	it("accepts percent-only splits that sum to 100", () => {
+		expect(
+			isSplitValid(10_000, {
+				splits: [
+					{ plId: "pl-roth", mode: "percent", value: 60 },
+					{ plId: "pl-trad", mode: "percent", value: 40 },
+				],
+			}),
+		).toBe(true);
+	});
+
+	it("rejects percent-only splits that don't sum to 100 (no remainder)", () => {
+		expect(
+			isSplitValid(10_000, {
+				splits: [
+					{ plId: "pl-roth", mode: "percent", value: 60 },
+					{ plId: "pl-trad", mode: "percent", value: 30 },
+				],
+			}),
+		).toBe(false);
+	});
+
+	it("accepts fixed legs paired with a remainder leg that absorbs what's left", () => {
+		expect(
+			isSplitValid(10_000, {
+				splits: [
+					{ plId: "pl-trad", mode: "fixed", value: 7500 },
+					{ plId: "pl-roth", mode: "remainder" },
+				],
+			}),
+		).toBe(true);
+	});
+
+	it("rejects splits where fixed legs over-allocate (negative remainder)", () => {
+		expect(
+			isSplitValid(10_000, {
+				splits: [
+					{ plId: "pl-trad", mode: "fixed", value: 12_000 },
+					{ plId: "pl-roth", mode: "remainder" },
+				],
+			}),
+		).toBe(false);
+	});
+
+	it("rejects fixed-only splits where the sum doesn't match the balance", () => {
+		expect(
+			isSplitValid(10_000, {
+				splits: [{ plId: "pl-trad", mode: "fixed", value: 9000 }],
+			}),
+		).toBe(false);
+	});
+
+	it("treats IGNORE_PL_ID legs as fully allocated for validation", () => {
+		// 60% Roth + 40% ignored should validate just like 60/40 to two real PL accounts.
+		expect(
+			isSplitValid(10_000, {
+				splits: [
+					{ plId: "pl-roth", mode: "percent", value: 60 },
+					{ plId: IGNORE_PL_ID, mode: "percent", value: 40 },
+				],
+			}),
+		).toBe(true);
+	});
+
+	it("rejects splits when balance is null", () => {
+		expect(
+			isSplitValid(null, {
+				splits: [{ plId: "pl-roth", mode: "percent", value: 100 }],
+			}),
+		).toBe(false);
+	});
+});
+
+describe("expandToSyncCandidates", () => {
+	it("returns one candidate for a plain mapping", () => {
+		expect(expandToSyncCandidates(acc(1000), "pl-1")).toEqual([
+			{ plId: "pl-1", balance: 1000, name: "401k" },
+		]);
+	});
+
+	it("returns no candidates when balance is null", () => {
+		expect(expandToSyncCandidates(acc(null), "pl-1")).toEqual([]);
+	});
+
+	it("returns no candidates when entry is undefined", () => {
+		expect(expandToSyncCandidates(acc(1000), undefined)).toEqual([]);
+	});
+
+	it("splits by percent", () => {
+		const m: SplitMapping = {
+			splits: [
+				{ plId: "pl-roth", mode: "percent", value: 60 },
+				{ plId: "pl-trad", mode: "percent", value: 40 },
+			],
+		};
+		expect(expandToSyncCandidates(acc(10_000), m)).toEqual([
+			{ plId: "pl-roth", balance: 6000, name: "401k" },
+			{ plId: "pl-trad", balance: 4000, name: "401k" },
+		]);
+	});
+
+	it("treats fixed legs as absolute dollar amounts", () => {
+		const m: SplitMapping = {
+			splits: [
+				{ plId: "pl-trad", mode: "fixed", value: 7500 },
+				{ plId: "pl-roth", mode: "remainder" },
+			],
+		};
+		expect(expandToSyncCandidates(acc(10_000), m)).toEqual([
+			{ plId: "pl-trad", balance: 7500, name: "401k" },
+			{ plId: "pl-roth", balance: 2500, name: "401k" },
+		]);
+	});
+
+	it("computes remainder as total minus fixed and percent legs", () => {
+		const m: SplitMapping = {
+			splits: [
+				{ plId: "pl-a", mode: "percent", value: 25 }, // 2500
+				{ plId: "pl-b", mode: "fixed", value: 1500 },
+				{ plId: "pl-c", mode: "remainder" }, // 6000
+			],
+		};
+		const out = expandToSyncCandidates(acc(10_000), m);
+		expect(out.map((c) => c.balance)).toEqual([2500, 1500, 6000]);
+	});
+
+	it("splits remainder equally across multiple remainder legs", () => {
+		const m: SplitMapping = {
+			splits: [
+				{ plId: "pl-a", mode: "fixed", value: 1000 },
+				{ plId: "pl-b", mode: "remainder" },
+				{ plId: "pl-c", mode: "remainder" },
+			],
+		};
+		const out = expandToSyncCandidates(acc(5000), m);
+		expect(out.map((c) => c.balance)).toEqual([1000, 2000, 2000]);
+	});
+
+	it("passes through a negative remainder when fixed/percent over-allocate", () => {
+		const m: SplitMapping = {
+			splits: [
+				{ plId: "pl-a", mode: "fixed", value: 12_000 },
+				{ plId: "pl-b", mode: "remainder" },
+			],
+		};
+		const out = expandToSyncCandidates(acc(10_000), m);
+		expect(out.map((c) => c.balance)).toEqual([12_000, -2000]);
+	});
+
+	it("returns no candidates when split has zero legs", () => {
+		expect(expandToSyncCandidates(acc(1000), { splits: [] })).toEqual([]);
+	});
+
+	it("drops legs targeting IGNORE_PL_ID from the candidate list", () => {
+		const m: SplitMapping = {
+			splits: [
+				{ plId: "pl-roth", mode: "percent", value: 60 },
+				{ plId: IGNORE_PL_ID, mode: "percent", value: 40 },
+			],
+		};
+		expect(expandToSyncCandidates(acc(10_000), m)).toEqual([
+			{ plId: "pl-roth", balance: 6000, name: "401k" },
+		]);
+	});
+
+	it("drops a single mapping that points at IGNORE_PL_ID", () => {
+		expect(expandToSyncCandidates(acc(1000), IGNORE_PL_ID)).toEqual([]);
+	});
+
+	it("drops split legs whose plId is empty (defensive against unfinished edits)", () => {
+		const m: SplitMapping = {
+			splits: [
+				{ plId: "pl-roth", mode: "percent", value: 60 },
+				{ plId: "", mode: "percent", value: 40 },
+			],
+		};
+		expect(expandToSyncCandidates(acc(10_000), m)).toEqual([
+			{ plId: "pl-roth", balance: 6000, name: "401k" },
+		]);
+	});
+});

--- a/lib/mapping.test.ts
+++ b/lib/mapping.test.ts
@@ -224,6 +224,36 @@ describe("isSplitValid", () => {
 			}),
 		).toBe(false);
 	});
+
+	it("accepts a single remainder leg on a negative (liability) balance", () => {
+		expect(
+			isSplitValid(-2000, {
+				splits: [{ plId: "pl-debt", mode: "remainder" }],
+			}),
+		).toBe(true);
+	});
+
+	it("accepts percent + remainder on a negative (liability) balance", () => {
+		expect(
+			isSplitValid(-2000, {
+				splits: [
+					{ plId: "pl-a", mode: "percent", value: 50 },
+					{ plId: "pl-b", mode: "remainder" },
+				],
+			}),
+		).toBe(true);
+	});
+
+	it("rejects a percent leg that overshoots a negative balance past the remainder", () => {
+		expect(
+			isSplitValid(-2000, {
+				splits: [
+					{ plId: "pl-a", mode: "percent", value: 150 },
+					{ plId: "pl-b", mode: "remainder" },
+				],
+			}),
+		).toBe(false);
+	});
 });
 
 describe("expandToSyncCandidates", () => {

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -1,0 +1,229 @@
+import type {
+	Account,
+	PLAccountId,
+	SplitLeg,
+	SplitMapping,
+	SyncEntry,
+} from "~/types";
+
+/**
+ * Sentinel `plId` used as a split-leg target to mean "intentionally don't sync
+ * this portion of the source balance to PL." Legs with this target are dropped
+ * by `expandToSyncCandidates` and excluded from `mappingTargets`, but pass the
+ * `isSplitValid` "every leg has a plId selected" check — so users can express
+ * partial syncs (e.g. "60% Roth, 40% ignored") without leaving validation in
+ * an under-allocated state.
+ */
+export const IGNORE_PL_ID = "__ignore__";
+
+/** True for the sentinel "don't sync" target. */
+export function isIgnoreTarget(plId: string): boolean {
+	return plId === IGNORE_PL_ID;
+}
+
+/** Type guard: does this mapping entry split across multiple PL accounts? */
+export function isSplitMapping(
+	entry: PLAccountId | SplitMapping | undefined,
+): entry is SplitMapping {
+	return (
+		typeof entry === "object" &&
+		entry !== null &&
+		Array.isArray((entry as { splits?: unknown }).splits)
+	);
+}
+
+/**
+ * Returns every real PL account id this mapping entry targets — one for a
+ * plain mapping, one-per-leg for a split mapping. Sentinel `IGNORE_PL_ID`
+ * legs are filtered out so they never count as cross-source overlap targets.
+ */
+export function mappingTargets(
+	entry: PLAccountId | SplitMapping | undefined,
+): PLAccountId[] {
+	if (!entry) return [];
+
+	if (isSplitMapping(entry)) {
+		return entry.splits
+			.map((leg) => leg.plId)
+			.filter((plId) => !isIgnoreTarget(plId));
+	}
+
+	if (isIgnoreTarget(entry)) return [];
+
+	return [entry];
+}
+
+/**
+ * Roll-up of a split's allocation math against a given balance. Single source
+ * of truth used by `isSplitValid`, `expandToSyncCandidates`, and the
+ * `SplitEditor` status pill — three places that must agree.
+ */
+export type SplitSummary = {
+	/** Sum of all `fixed` legs (raw dollars). */
+	fixedSum: number;
+	/** Sum of `percent` legs resolved to dollars: Σ(balance × value / 100). */
+	percentSum: number;
+	/** Sum of `percent` legs' percentage values (e.g. 60 + 40 = 100). */
+	percentTotal: number;
+	/** How many legs are `remainder` mode. */
+	remainderCount: number;
+	/** Per-`remainder`-leg dollar share, or 0 if there are none. */
+	remainderShare: number;
+	/** Total dollars allocated across all legs (fixed + percent + remainder × N). */
+	allocated: number;
+	/** balance − allocated. Positive ⇒ under-allocated, negative ⇒ over. */
+	unallocated: number;
+};
+
+/** Tolerance for "dollars match the balance" — guards float comparison. */
+export const SPLIT_DOLLAR_TOLERANCE = 0.005;
+/** Tolerance for "percent legs total 100" — guards float comparison. */
+export const SPLIT_PERCENT_TOLERANCE = 0.01;
+
+/** Compute the allocation roll-up for a split against a known balance. */
+export function summarizeSplit(
+	balance: number,
+	splits: SplitLeg[],
+): SplitSummary {
+	let fixedSum = 0;
+	let percentSum = 0;
+	let percentTotal = 0;
+	let remainderCount = 0;
+
+	for (const leg of splits) {
+		if (leg.mode === "fixed") {
+			fixedSum += leg.value;
+		} else if (leg.mode === "percent") {
+			percentSum += (balance * leg.value) / 100;
+			percentTotal += leg.value;
+		} else {
+			remainderCount += 1;
+		}
+	}
+
+	const remainderShare =
+		remainderCount > 0 ? (balance - fixedSum - percentSum) / remainderCount : 0;
+	const allocated = fixedSum + percentSum + remainderShare * remainderCount;
+	const unallocated = balance - allocated;
+
+	return {
+		fixedSum,
+		percentSum,
+		percentTotal,
+		remainderCount,
+		remainderShare,
+		allocated,
+		unallocated,
+	};
+}
+
+/**
+ * Discriminant-preserving setter for a leg's `plId`. Spreading `{...leg, plId}`
+ * over a `SplitLeg` loses the union narrowing and forces `as` casts at the
+ * call site — this helper keeps the discriminant intact instead.
+ */
+export function withLegPlId(leg: SplitLeg, plId: string): SplitLeg {
+	return leg.mode === "remainder"
+		? { plId, mode: "remainder" }
+		: { plId, mode: leg.mode, value: leg.value };
+}
+
+/**
+ * Discriminant-preserving setter for a `fixed`/`percent` leg's `value`. No-op
+ * on `remainder` legs (which don't carry a value).
+ */
+export function withLegValue(leg: SplitLeg, value: number): SplitLeg {
+	if (leg.mode === "remainder") return leg;
+	return { plId: leg.plId, mode: leg.mode, value };
+}
+
+/**
+ * Returns `true` when this mapping entry is a syncable shape:
+ * - Plain (string) mappings are always considered valid here — emptiness is
+ *   handled at the storage layer (an empty string is deleted from the table).
+ * - Split mappings must:
+ *   (a) have ≥1 leg
+ *   (b) have a `plId` selected on every leg
+ *   (c) not over-allocate
+ *   (d) when there's no `remainder` leg, any percent legs must sum to ~100%
+ *       and the resolved totals must match the account balance (no
+ *       unallocated dollars).
+ *
+ * Returns `false` for splits when the account balance is `null`, since
+ * over/under-allocation can't be checked without it.
+ */
+export function isSplitValid(
+	balance: number | null,
+	entry: PLAccountId | SplitMapping | undefined,
+): boolean {
+	if (!isSplitMapping(entry)) return true;
+	if (balance === null) return false;
+	if (entry.splits.length === 0) return false;
+	if (entry.splits.some((leg) => !leg.plId)) return false;
+
+	const { fixedSum, percentSum, percentTotal, remainderCount } = summarizeSplit(
+		balance,
+		entry.splits,
+	);
+
+	if (remainderCount > 0) {
+		// A remainder leg absorbs whatever's left — only invalid when fixed +
+		// percent over-allocate, leaving the remainder negative.
+		return fixedSum + percentSum <= balance + SPLIT_DOLLAR_TOLERANCE;
+	}
+
+	if (
+		entry.splits.some((l) => l.mode === "percent") &&
+		Math.abs(percentTotal - 100) > SPLIT_PERCENT_TOLERANCE
+	) {
+		return false;
+	}
+
+	return Math.abs(fixedSum + percentSum - balance) <= SPLIT_DOLLAR_TOLERANCE;
+}
+
+/**
+ * Expands one source account + its mapping entry into the set of
+ * `{plId, balance, name}` candidates that should flow to the additive grouping pass.
+ *
+ * - Single mapping → one candidate carrying the full balance.
+ * - Split mapping → one candidate per leg, with the leg's portion of the balance:
+ *   - `fixed`: leg.value (as-is)
+ *   - `percent`: total × value / 100
+ *   - `remainder`: total − (fixed + percent), split equally if there are multiple remainder legs
+ *
+ * Legs targeting `IGNORE_PL_ID` or carrying an empty `plId` are dropped — the
+ * former is the user's explicit "don't sync" choice; the latter is defense
+ * against an unfinished edit slipping past validation.
+ *
+ * Returns `[]` when the account balance is null, the entry is missing, or the
+ * split has no legs. Negative remainder values are passed through (so the user
+ * can see when fixed/percent legs over-allocate).
+ */
+export function expandToSyncCandidates(
+	account: Account,
+	entry: PLAccountId | SplitMapping | undefined,
+): SyncEntry[] {
+	if (!entry || account.balance === null) return [];
+
+	if (!isSplitMapping(entry)) {
+		if (isIgnoreTarget(entry)) return [];
+		return [{ plId: entry, balance: account.balance, name: account.name }];
+	}
+
+	if (entry.splits.length === 0) return [];
+
+	const total = account.balance;
+	const { remainderShare } = summarizeSplit(total, entry.splits);
+
+	const candidates: SyncEntry[] = [];
+	for (const leg of entry.splits) {
+		if (!leg.plId || isIgnoreTarget(leg.plId)) continue;
+		let balance: number;
+		if (leg.mode === "fixed") balance = leg.value;
+		else if (leg.mode === "percent") balance = (total * leg.value) / 100;
+		else balance = remainderShare;
+		candidates.push({ plId: leg.plId, balance, name: account.name });
+	}
+	return candidates;
+}

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -167,9 +167,9 @@ export function isSplitValid(
 	);
 
 	if (remainderCount > 0) {
-		// A remainder leg absorbs whatever's left — only invalid when fixed +
-		// percent over-allocate, leaving the remainder negative.
-		return fixedSum + percentSum <= balance + SPLIT_DOLLAR_TOLERANCE;
+		return balance >= 0
+			? fixedSum + percentSum <= balance + SPLIT_DOLLAR_TOLERANCE
+			: fixedSum + percentSum >= balance - SPLIT_DOLLAR_TOLERANCE;
 	}
 
 	if (

--- a/lib/storage.test.ts
+++ b/lib/storage.test.ts
@@ -162,6 +162,24 @@ describe("getOtherSourceMappings", () => {
 		const result = await getOtherSourceMappings("vanguard");
 		expect(result["pl-checking"]).toBeUndefined();
 	});
+
+	it("traverses split-mapping legs as targets of the source", async () => {
+		vi.mocked(browser.storage.local.get).mockResolvedValueOnce({
+			[mappingsKey("ynab")]: {
+				"y-1": {
+					splits: [
+						{ plId: "pl-roth", mode: "percent", value: 60 },
+						{ plId: "pl-trad", mode: "remainder" },
+					],
+				},
+			},
+		} as any);
+		const result = await getOtherSourceMappings("vanguard");
+		expect(result).toEqual({
+			"pl-roth": ["ynab"],
+			"pl-trad": ["ynab"],
+		});
+	});
 });
 
 describe("setMappings", () => {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -12,6 +12,7 @@ import {
 } from "~/plugins";
 
 import type { Account, Credentials, PLMappings, PlAccount } from "~/types";
+import { mappingTargets } from "./mapping";
 
 /**
  * The key used to look up a source account in the mapping table.
@@ -299,9 +300,11 @@ export async function getOtherSourceMappings(
 
 		if (!m) continue;
 
-		for (const plId of Object.values(m)) {
-			if (!result[plId]) result[plId] = [];
-			result[plId].push(plugin.id);
+		for (const entry of Object.values(m)) {
+			for (const plId of mappingTargets(entry)) {
+				if (!result[plId]) result[plId] = [];
+				result[plId].push(plugin.id);
+			}
 		}
 	}
 	return result;

--- a/types/index.ts
+++ b/types/index.ts
@@ -18,8 +18,31 @@ export type PLAccountId = string;
  */
 export type SourceAccountKey = string;
 
-/** `sourceAccountKey` → `plAccountId`. One entry per mapped source row. */
-export type PLMappings = Record<SourceAccountKey, PLAccountId>;
+/**
+ * One leg of a split mapping: a portion of a single source balance routed to
+ * a specific PL account. `mode` decides how `value` is interpreted:
+ * - `percent` — `value` is 0–100, leg amount = total × value/100
+ * - `fixed` — `value` is an absolute dollar amount
+ * - `remainder` — `value` is ignored; leg absorbs whatever the other legs leave
+ */
+export type SplitLeg =
+	| { plId: PLAccountId; mode: "percent"; value: number }
+	| { plId: PLAccountId; mode: "fixed"; value: number }
+	| { plId: PLAccountId; mode: "remainder" };
+
+/**
+ * Split a single source account across multiple PL accounts. Used as an
+ * alternative to a plain `PLAccountId` in the `PLMappings` value union.
+ */
+export type SplitMapping = { splits: SplitLeg[] };
+
+/**
+ * `sourceAccountKey` → `plAccountId` (single target) **or** `SplitMapping`
+ * (split across multiple targets). One entry per mapped source row.
+ *
+ * Use `isSplitMapping` (in `~/lib/storage`) to discriminate the union.
+ */
+export type PLMappings = Record<SourceAccountKey, PLAccountId | SplitMapping>;
 
 /** Credential field id (e.g. `"accessToken"`) → user-entered value. */
 export type Credentials = Record<string, string>;


### PR DESCRIPTION
- Adds ability to split accounts by % or amount
- Enables partial syncing by dropping remaining unmapped amount
- Increases the size of the panel to better fit the split logic panel

Closes #52 